### PR TITLE
Implemented Rust Bindings, feature-parity with `honey_coverage`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,9 @@ DerivedData/
 # End of https://www.toptal.com/developers/gitignore/api/macos,linux,clion+all,xcode,cmake
 
 !honey_driver/Makefile
+
+# VSCode Local history plugin
+/.history/
+
+# VSCode
+/.vscode/

--- a/honey_analyzer/capture/ha_capture_session.c
+++ b/honey_analyzer/capture/ha_capture_session.c
@@ -101,7 +101,7 @@ int ha_capture_session_set_trace_enable(ha_capture_session_t session, uint8_t en
 }
 
 int ha_capture_session_configure_tracing(ha_capture_session_t session, uint32_t pid,
-                                         ha_capture_session_range_filter filters[4]) {
+                                         const ha_capture_session_range_filter filters[4]) {
     hb_driver_packet_configure_trace configure_trace;
 //    bzero(&configure_trace, sizeof configure_trace);
 
@@ -110,7 +110,7 @@ int ha_capture_session_configure_tracing(ha_capture_session_t session, uint32_t 
 
     for (int i = 0; i < 4; i++) {
         hb_driver_packet_range_filter *dst_filter = &configure_trace.filters[i];
-        ha_capture_session_range_filter *src_filter = &filters[i];
+        const ha_capture_session_range_filter *src_filter = &filters[i];
         dst_filter->enabled = src_filter->enabled;
         dst_filter->start_address = src_filter->start;
         dst_filter->stop_address = src_filter->stop;
@@ -130,7 +130,7 @@ static int get_trace_buffer_lengths(ha_capture_session_t session, uint64_t *pack
     return ioctl(session->fd, HB_DRIVER_PACKET_IOC_GET_TRACE_LENGTHS, &get_trace_lengths);
 }
 
-int ha_capture_get_trace(ha_capture_session_t session, uint8_t **trace_buffer, uint64_t *trace_length) {
+int ha_capture_session_get_trace(ha_capture_session_t session, uint8_t **trace_buffer, uint64_t *trace_length) {
     int result;
 
     uint64_t packet_byte_count;

--- a/honey_analyzer/capture/ha_capture_session.h
+++ b/honey_analyzer/capture/ha_capture_session.h
@@ -57,7 +57,7 @@ int ha_capture_session_set_global_buffer_size(ha_capture_session_t session, uint
 /**
  * Starts or stops tracing on this session's CPU
  * @param enabled Non-zero if tracing should be enabled
- * @param If the trace buffer output should be reset to the start. If false and the trace has not been reconfigured
+ * @param reset_output If the trace buffer output should be reset to the start. If false and the trace has not been reconfigured
  * since being disabled, tracing will resume without damaging data.
  * @return A status code. Negative on error.
  */
@@ -72,7 +72,7 @@ int ha_capture_session_set_trace_enable(ha_capture_session_t session, uint8_t en
  * @return A status code. Negative on error.
  */
 int ha_capture_session_configure_tracing(ha_capture_session_t session, uint32_t pid,
-                                         ha_capture_session_range_filter filters[4]);
+                                         const ha_capture_session_range_filter filters[4]);
 
 /**
  * Gets the trace buffer. This trace buffer has a stop codon (PT_TRACE_END) at the end of it.
@@ -82,6 +82,6 @@ int ha_capture_session_configure_tracing(ha_capture_session_t session, uint32_t 
  * @param trace_length The location to place the length of the trace and the stop codon. Nothing is written on error.
  * @return A status code. Negative on error.
  */
-int ha_capture_get_trace(ha_capture_session_t session, uint8_t **trace_buffer, uint64_t *trace_length);
+int ha_capture_session_get_trace(ha_capture_session_t session, uint8_t **trace_buffer, uint64_t *trace_length);
 
 #endif //HA_CAPTURE_SESSION_H

--- a/honey_analyzer/processor_trace/ha_pt_decoder.c
+++ b/honey_analyzer/processor_trace/ha_pt_decoder.c
@@ -538,14 +538,14 @@ int ha_pt_decoder_decode_until_caches_filled(ha_pt_decoder_t decoder) {
         case __extension__ 0b11000011:    /* MNT -- ignoring because I also don't know what this is */
         case __extension__ 0b01110011:    /* TMA -- ignoring because we don't support time */
         default:
-            return -HA_PT_UNSUPPORTED_TRACE_PACKET;
+            return -HA_PT_DECODER_UNSUPPORTED_TRACE_PACKET;
     }
 
     handle_pt_mtc: /* ignoring because we don't support time */
     handle_pt_tsc: /* ignoring because we don't support time */
     handle_pt_cyc: /* ignoring because we don't support time */
     handle_pt_error: /* just an error */
-        return -HA_PT_UNSUPPORTED_TRACE_PACKET;
+        return -HA_PT_DECODER_UNSUPPORTED_TRACE_PACKET;
 
     handle_pt_exit:
         //We hit the stop codon

--- a/honey_analyzer/processor_trace/ha_pt_decoder.h
+++ b/honey_analyzer/processor_trace/ha_pt_decoder.h
@@ -27,7 +27,7 @@ typedef enum {
      */
     HA_PT_DECODER_TRACE_DESYNC = 4,
     /** An unsupported packet was found in the PT stream. */
-    HA_PT_UNSUPPORTED_TRACE_PACKET = 5,
+    HA_PT_DECODER_UNSUPPORTED_TRACE_PACKET = 5,
     /** The target address was not found in the binary map. */
     HA_PT_DECODER_NO_MAP = 6,
 } ha_pt_decoder_status;

--- a/honey_analyzer/trace_analysis/ha_session.c
+++ b/honey_analyzer/trace_analysis/ha_session.c
@@ -117,7 +117,7 @@ int64_t block_decode(ha_session_t session) {
 #endif
 
         if (LO32(index) >= session->hive->block_count) {
-            ANALYSIS_LOGGER("\tNo map error, index = %"PRIu32", block count = %"PRIu64"\n", LO32(index),
+            ANALYSIS_LOGGER("\tNo map error, index = %"PRIx32", block count = %"PRIx64"\n", LO32(index),
                             session->hive->block_count);
             return -HA_PT_DECODER_NO_MAP;
         }

--- a/honey_coverage/hc_tree_set.c
+++ b/honey_coverage/hc_tree_set.c
@@ -42,6 +42,10 @@ static int internal_iterate_all_nodes(hc_tree_set_t tree_set, internal_iterate_n
     if (!tree_stack) {
         goto CLEANUP;
     }
+    if (!tree_set->root) {
+        result = 0;
+        goto CLEANUP;
+    }
 
     unsigned long long tree_stack_count = 1;
     tree_stack[0] = tree_set->root;

--- a/honey_coverage/main.c
+++ b/honey_coverage/main.c
@@ -77,7 +77,7 @@ void suspend_process(pid_t pid) {
     ptrace(PTRACE_INTERRUPT, pid, (caddr_t) 1, 0);
 }
 
-void unsuspended_process(pid_t pid) {
+void unsuspend_process(pid_t pid) {
     ptrace(PTRACE_CONT, pid, (caddr_t) 1, 0);
 }
 
@@ -163,7 +163,7 @@ int main(int argc, const char * argv[]) {
         goto CLEANUP;
     }
 
-    unsuspended_process(pid);
+    unsuspend_process(pid);
 
     if ((result = waitpid(pid, &result, 0) < 0)) {
         printf(TAGE "Failed to wait for process, error = %d\n", result);
@@ -177,7 +177,7 @@ int main(int argc, const char * argv[]) {
 
     uint8_t *terminated_buffer = NULL;
     uint64_t buffer_length = 0;
-    if ((result = ha_capture_get_trace(capture_session, &terminated_buffer, &buffer_length)) < 0) {
+    if ((result = ha_capture_session_get_trace(capture_session, &terminated_buffer, &buffer_length)) < 0) {
         printf(TAGE "Failed to get trace buffer, error = %d\n", result);
         goto CLEANUP;
     }

--- a/honey_driver/.gitignore
+++ b/honey_driver/.gitignore
@@ -1,0 +1,8 @@
+Module.symvers
+*.mod
+*.mod.c
+*.ko
+*.cmd
+*.o
+modules.order
+

--- a/honey_driver/honey_driver.c
+++ b/honey_driver/honey_driver.c
@@ -77,7 +77,7 @@
 #define ENABLE_LOGGING 0
 
 #if ENABLE_LOGGING
-#define LOGGER(format, ...) (printf("[" __FILE__ "] " format, ##__VA_ARGS__))
+#define LOGGER(format, ...) (printk(format, ##__VA_ARGS__))
 #else
 #define LOGGER(format, ...)  (void)0
 #endif

--- a/honeybee_shared/hb_hive.c
+++ b/honeybee_shared/hb_hive.c
@@ -39,7 +39,7 @@ hb_hive *hb_hive_alloc(const char *hive_path) {
         goto CLEANUP;
     }
 
-    map_handle = mmap(NULL, sb.st_size, PROT_READ, MAP_SHARED, fd, 0);
+    map_handle = mmap(NULL, sb.st_size, PROT_READ, MAP_PRIVATE | MAP_POPULATE, fd, 0);
     if (map_handle == MAP_FAILED) {
         printf(TAG "Could not mmap file '%s'!\n", hive_path);
         goto CLEANUP;

--- a/rust-honey_analyzer-sys/.gitignore
+++ b/rust-honey_analyzer-sys/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+/target/

--- a/rust-honey_analyzer-sys/Cargo.toml
+++ b/rust-honey_analyzer-sys/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust-honey_analyzer-sys"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[build-dependencies]
+bindgen = "0.59.2"
+
+[dependencies]

--- a/rust-honey_analyzer-sys/build.rs
+++ b/rust-honey_analyzer-sys/build.rs
@@ -1,0 +1,42 @@
+extern crate bindgen;
+
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    // Tell cargo to tell rustc to link the system bzip2
+    // shared library.
+    println!("cargo:rustc-link-lib=static=honey_analyzer");
+    println!("cargo:rustc-link-search=../build/");
+
+    Command::new("make")
+        .args(&["-C", "../build"])
+        .output()
+        .expect("could not run make");
+
+    // Tell cargo to invalidate the built crate whenever the wrapper changes
+    println!("cargo:rerun-if-changed=wrapper.h");
+    println!("cargo:rerun-if-changed=../build/libhoney_analyzer.a");
+
+    // The bindgen::Builder is the main entry point
+    // to bindgen, and lets you build up options for
+    // the resulting bindings.
+    let bindings = bindgen::Builder::default()
+        // The input header we would like to generate
+        // bindings for.
+        .header("wrapper.h")
+        // Tell cargo to invalidate the built crate whenever any of the
+        // included header files changed.
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        // Finish the builder and generate the bindings.
+        .generate()
+        // Unwrap the Result and panic on failure.
+        .expect("Unable to generate bindings");
+
+    // Write the bindings to the $OUT_DIR/bindings.rs file.
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/rust-honey_analyzer-sys/src/lib.rs
+++ b/rust-honey_analyzer-sys/src/lib.rs
@@ -1,0 +1,5 @@
+#![allow(non_upper_case_globals)]
+#![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
+
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

--- a/rust-honey_analyzer-sys/wrapper.h
+++ b/rust-honey_analyzer-sys/wrapper.h
@@ -1,0 +1,3 @@
+#include "../honey_analyzer/honey_analyzer.h"
+#include "../honey_analyzer/ha_debug_switch.h"
+#include "../honeybee_shared/hb_hive.h"

--- a/rust-honey_analyzer/.gitignore
+++ b/rust-honey_analyzer/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+/target/

--- a/rust-honey_analyzer/Cargo.toml
+++ b/rust-honey_analyzer/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "rust-honey_analyzer"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+# [profile.release]
+# debug = true
+
+[dependencies]
+rust-honey_analyzer-sys = { path = "../rust-honey_analyzer-sys" }
+libc = "0.2.117"
+nix = "0.23.1"
+clap = {version = "3.0.14", features = ["cargo"]}
+parse_int = "0.6.0"
+spawn-ptrace = "0.1.2"
+time = "0.3.7"
+itertools = "0.10.3"
+datasize = "0.2.10"
+residua-uleb128 = "0.2.0"

--- a/rust-honey_analyzer/src/analysis_session.rs
+++ b/rust-honey_analyzer/src/analysis_session.rs
@@ -1,0 +1,85 @@
+use std::ptr;
+
+use libc::c_void;
+use nix::errno::Errno;
+use rust_honey_analyzer_sys::*;
+
+use crate::pt_decoder_status::PTDecoderStatus;
+
+use super::hive::HoneyBeeHive;
+
+extern "C" fn coverage_trampoline<F>(_: ha_session_t, context: *mut c_void, unslid_ip: u64)
+    where F: FnMut(u64)
+{
+    unsafe {
+        let cb = &mut *(context as *mut F);
+        (cb)(unslid_ip)
+    }
+}
+
+pub struct AnalysisSession {
+    sess: ha_session_t,
+    _hive: HoneyBeeHive,
+    current_buffer: Vec<u8>
+}
+
+type ErrnoResult<T> = std::result::Result<T, Errno>;
+
+impl Drop for AnalysisSession {
+    fn drop(&mut self) {
+        unsafe {
+            ha_session_free(self.sess)
+        }
+    }
+}
+impl AnalysisSession {
+    pub fn new(hive: HoneyBeeHive) -> ErrnoResult<AnalysisSession> {
+        let mut sess = ptr::null_mut();
+        let mut hive = hive;
+        unsafe {
+            let res  = ha_session_alloc(&mut sess, hive.get_inner());
+            if res < 0 {
+                return Err(Errno::from_i32(-res));
+            }
+            return Ok(AnalysisSession{
+                sess,
+                _hive: hive,
+                current_buffer: vec![]
+            })
+        }
+    }
+
+
+    pub fn decode_with_callback<F>(&mut self, callback: F) -> Result<(), PTDecoderStatus>
+        where F: FnMut(u64)
+    {
+        let mut callback = callback;
+        unsafe {
+            let context = &mut callback as *mut F as *mut c_void;
+
+            let res = ha_session_decode(self.sess, Some(coverage_trampoline::<F>), context);
+            assert!(res < 0, "ha_session_decode should always return -EOF on success!");
+            let res: PTDecoderStatus = (-res).try_into().unwrap();
+            match res {
+                PTDecoderStatus::EndOfStream => Ok(()),
+                _ => Err(res)
+            }
+        }
+    }
+
+    pub fn reconfigure_with_terminated_trace_buffer(&mut self, buf: Vec<u8>, trace_slide: usize) -> ErrnoResult<()> {
+        self.current_buffer = buf;
+        unsafe {
+            let res = ha_session_reconfigure_with_terminated_trace_buffer(
+                self.sess,
+                self.current_buffer.as_mut_ptr(),
+                self.current_buffer.len().try_into().unwrap(),
+                trace_slide.try_into().unwrap());
+            if res < 0 {
+                return Err(Errno::from_i32(-res))
+            }
+            Ok(())
+        }
+    }
+
+}

--- a/rust-honey_analyzer/src/bin/baseline_pin_cpu_ptrace_execution.rs
+++ b/rust-honey_analyzer/src/bin/baseline_pin_cpu_ptrace_execution.rs
@@ -1,0 +1,136 @@
+use std::{path::PathBuf, process::{Command, Child}, os::unix::prelude::CommandExt, io::ErrorKind};
+
+use clap::{self, Arg, ValueHint, AppSettings};
+use nix::sys::{ptrace, personality};
+use nix::sys::wait::{waitpid, WaitStatus};
+use nix::sys::signal::Signal;
+use nix::errno::Errno;
+use nix::unistd::Pid;
+use nix::sched::{sched_setaffinity, CpuSet};
+
+use rust_honey_analyzer::{
+    capture_filter::parse_capture_filter
+};
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn get_epoch_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis()
+}
+
+fn io_error(e: Errno) -> std::io::Error {
+    std::io::Error::from_raw_os_error(e as i32)
+}
+fn spawn_suspended(args: &[&str]) -> Result<Child, std::io::Error> {
+    let mut cmd = Command::new(args[0]);
+        cmd.args(&args[1..]);
+
+    unsafe {
+        cmd.pre_exec(|| {
+            ptrace::traceme().map_err(io_error)?;
+            let old_personality = personality::get().map_err(io_error )?;
+            personality::set(old_personality.union(personality::Persona::ADDR_NO_RANDOMIZE))?;
+            Ok(())
+        });
+    }
+    let child = cmd.spawn()?;
+    let child_pid = child.id();
+    let res = waitpid(Pid::from_raw(child_pid as i32), None);
+    match res {
+        Ok(WaitStatus::Stopped(waited_pid, Signal::SIGTRAP)) => {
+            assert!(child_pid == child.id(), "Got SIGTRAP from the wrong process?? child_pid={}, got pid={}", child_pid, waited_pid);
+            Ok(child)
+        },
+        other => Err(
+            std::io::Error::new(
+                ErrorKind::Other,
+                format!("Got incorrect child status: {:?}", other),
+            ))
+    }
+}
+
+fn pin_process_to_cpu(pid: u32, cpu: u16) -> Result<(), Errno>{
+    let mut cpuset = CpuSet::new();
+    cpuset.set(cpu.try_into().unwrap())?;
+    sched_setaffinity(Pid::from_raw(pid.try_into().unwrap()), &cpuset)?;
+    Ok(())
+}
+
+fn err_str(e: impl ToString) -> String {
+    e.to_string()
+}
+
+// fn suspend_process(pid: u32) {
+//     ptrace::interrupt(Pid::from_raw(pid as i32)).expect("Could not interrupt child process!");
+// }
+
+fn unsuspend_process(pid: u32) {
+    ptrace::cont(Pid::from_raw(pid as i32), None).expect("Could not continue child process!");
+}
+
+fn main() -> Result<(), String> {
+    let matches = clap::app_from_crate!()
+        .setting(AppSettings::TrailingVarArg)
+        .arg(
+            Arg::new("hive_path")
+                .help("Path to the pre-generated hive file for the target binary")
+                .value_hint(ValueHint::FilePath)
+                .required(true)
+                .validator(|s| {
+                    let pb = PathBuf::from(s);
+                    if !pb.exists() {
+                        return Err(format!("Hive file @ {:?} does not exist!", pb))
+                    }
+                    pb.canonicalize().map_err(err_str)
+                })
+        )
+        .arg(
+            Arg::new("filter")
+                .required(true)
+                .help("Address range to filter")
+                .validator(parse_capture_filter)
+                .value_hint(ValueHint::Other)
+        )
+        .arg(Arg::new("command")
+            .required(true)
+            .takes_value(true)
+            .multiple_values(true)
+            .value_hint(ValueHint::CommandWithArguments)
+            .last(true)
+        )
+        .get_matches();
+
+    let hive_path: PathBuf = matches.value_of_t("hive_path").unwrap();
+    let cmdline = matches.values_of("command").unwrap().collect::<Vec<_>>();
+
+    println!("hive_path={hive_path:?}, filters={:?}, cmdline={cmdline:?}");
+
+    let clk_pre_all = get_epoch_ms();
+
+    // CAPTURE
+    let mut child = spawn_suspended(&cmdline).expect("Could not spawn child process");
+    pin_process_to_cpu(child.id(), 0u16).expect("Could not pin child process to CPU #0");
+
+    let clk_pre_unsuspend = get_epoch_ms();
+    unsuspend_process(child.id());
+
+    let exit_status = child.wait().expect("Failed to wait for child pid!");
+    println!("Child exited with status {:?}", exit_status);
+    let clk_post_child_exit = get_epoch_ms();
+
+    let timestamps = [clk_pre_all, clk_pre_unsuspend, clk_post_child_exit];
+    // let timestamps = timestamps[1..].iter()
+    //     .map(|curr| curr - timestamps[0])
+    //     .collect::<Vec<_>>();
+    let timestamps = timestamps[..timestamps.len()-1].iter()
+        .zip(timestamps[1..].iter())
+        .map(|(prev, curr)| curr - prev)
+        .zip(&["spawn & pin", "child_execution"])
+        .collect::<Vec<_>>();
+    println!("timestamps: {:?}", timestamps);
+
+    Ok(())
+}

--- a/rust-honey_analyzer/src/bin/baseline_pure_execution.rs
+++ b/rust-honey_analyzer/src/bin/baseline_pure_execution.rs
@@ -1,0 +1,92 @@
+use std::{path::PathBuf, process::{Command, Child}, os::unix::prelude::CommandExt};
+
+use clap::{self, Arg, ValueHint, AppSettings};
+use nix::sys::{personality};
+use nix::errno::Errno;
+
+use rust_honey_analyzer::capture_filter::parse_capture_filter;
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn get_epoch_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis()
+}
+
+fn io_error(e: Errno) -> std::io::Error {
+    std::io::Error::from_raw_os_error(e as i32)
+}
+fn spawn_suspended(args: &[&str]) -> Result<Child, std::io::Error> {
+    let mut cmd = Command::new(args[0]);
+        cmd.args(&args[1..]);
+
+    unsafe {
+        cmd.pre_exec(|| {
+            let old_personality = personality::get().map_err(io_error )?;
+            personality::set(old_personality.union(personality::Persona::ADDR_NO_RANDOMIZE))?;
+            Ok(())
+        });
+    }
+    let child = cmd.spawn()?;
+    Ok(child)
+}
+
+fn err_str(e: impl ToString) -> String {
+    e.to_string()
+}
+
+// fn suspend_process(pid: u32) {
+//     ptrace::interrupt(Pid::from_raw(pid as i32)).expect("Could not interrupt child process!");
+// }
+
+fn main() -> Result<(), String> {
+    let matches = clap::app_from_crate!()
+        .setting(AppSettings::TrailingVarArg)
+        .arg(
+            Arg::new("hive_path")
+                .help("Path to the pre-generated hive file for the target binary")
+                .value_hint(ValueHint::FilePath)
+                .required(true)
+                .validator(|s| {
+                    let pb = PathBuf::from(s);
+                    if !pb.exists() {
+                        return Err(format!("Hive file @ {:?} does not exist!", pb))
+                    }
+                    pb.canonicalize().map_err(err_str)
+                })
+        )
+        .arg(
+            Arg::new("filter")
+                .required(true)
+                .help("Address range to filter")
+                .validator(parse_capture_filter)
+                .value_hint(ValueHint::Other)
+        )
+        .arg(Arg::new("command")
+            .required(true)
+            .takes_value(true)
+            .multiple_values(true)
+            .value_hint(ValueHint::CommandWithArguments)
+            .last(true)
+        )
+        .get_matches();
+
+    let hive_path: PathBuf = matches.value_of_t("hive_path").unwrap();
+    let cmdline = matches.values_of("command").unwrap().collect::<Vec<_>>();
+
+    println!("hive_path={hive_path:?}, filters={:?}, cmdline={cmdline:?}");
+
+    let clk_pre_exec = get_epoch_ms();
+
+    // CAPTURE
+    let mut child = spawn_suspended(&cmdline).expect("Could not spawn child process");
+    let exit_status = child.wait().expect("Failed to wait for child pid!");
+    let clk_post_child_exit = get_epoch_ms();
+    println!("Child returned with status code {:?}", exit_status);
+
+    println!("pure execution: {:?}", clk_post_child_exit-clk_pre_exec);
+
+    Ok(())
+}

--- a/rust-honey_analyzer/src/bin/honey_analyzer.rs
+++ b/rust-honey_analyzer/src/bin/honey_analyzer.rs
@@ -1,0 +1,236 @@
+use std::{path::PathBuf, os::unix::prelude::CommandExt, io::ErrorKind};
+use std::process::{Command, Child};
+use std::io::Write;
+
+use clap::{self, Arg, ValueHint, AppSettings};
+use libc::pid_t;
+use nix::sys::{ptrace, personality, signal::Signal};
+use nix::sys::wait::{waitpid, WaitStatus};
+use nix::errno::Errno;
+use nix::unistd::Pid;
+use nix::sched::{sched_setaffinity, CpuSet};
+
+use rust_honey_analyzer::example_coverage_info::{CoverageTracker, FullTrace64Bit, TrivialDedupFullTrace64Bit, FullTrace32Bit, TrivialDedupFullTrace32Bit, LessTrivialDedupFullTrace32Bit, XorDiffULeb128CompressedTrace, BlockBTreeSetCoverageInfo, BlockHashSetCoverageInfo, EdgeBTreeSetCoverageInfo, EdgeHashSetCoverageInfo};
+use rust_honey_analyzer::hive::HoneyBeeHive;
+use rust_honey_analyzer::capture_session::CaptureSession;
+use rust_honey_analyzer::capture_filter::parse_capture_filter;
+use rust_honey_analyzer::analysis_session::AnalysisSession;
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn get_epoch_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis()
+}
+
+fn io_error(e: Errno) -> std::io::Error {
+    std::io::Error::from_raw_os_error(e as i32)
+}
+fn spawn_suspended(args: &[&str]) -> Result<Child, std::io::Error> {
+    let mut cmd = Command::new(args[0]);
+    cmd.args(&args[1..]);
+
+    unsafe {
+        cmd.pre_exec(|| {
+            ptrace::traceme().map_err(io_error)?;
+            let old_personality = personality::get().map_err(io_error )?;
+            personality::set(old_personality.union(personality::Persona::ADDR_NO_RANDOMIZE))?;
+            Ok(())
+        });
+    }
+    let child = cmd.spawn()?;
+    let child_pid = child.id();
+    let res = waitpid(Pid::from_raw(child_pid as i32), None);
+    match res {
+        Ok(WaitStatus::Stopped(waited_pid, Signal::SIGTRAP)) => {
+            assert!(child_pid == child.id(), "Got SIGTRAP from the wrong process?? child_pid={}, got pid={}", child_pid, waited_pid);
+            Ok(child)
+        },
+        other => Err(
+            std::io::Error::new(
+                ErrorKind::Other,
+                format!("Got incorrect child status: {:?}", other),
+            ))
+    }
+}
+
+fn pin_process_to_cpu(pid: u32, cpu: u16) {
+    let mut cpuset = CpuSet::new();
+    cpuset.set(cpu as usize).expect("Could not set CPU in set?");
+    sched_setaffinity(Pid::from_raw(pid as pid_t), &cpuset).expect("Could not set cpu affinity??");
+}
+
+fn err_str(e: impl ToString) -> String {
+    e.to_string()
+}
+
+// fn suspend_process(pid: u32) {
+//     ptrace::interrupt(Pid::from_raw(pid as i32)).expect("Could not interrupt child process!");
+// }
+
+fn unsuspend_process(pid: u32) {
+    ptrace::cont(Pid::from_raw(pid as i32), None).expect("Could not continue child process!");
+}
+
+fn append_to_file(path: &str, content: &str) {
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .append(true)
+        .create(true)
+        .open(path)
+        .unwrap();
+    write!(file, "{}", content).unwrap();
+}
+
+fn main() -> Result<(), String> {
+    let matches = clap::app_from_crate!()
+        .setting(AppSettings::TrailingVarArg)
+        .arg(
+            Arg::new("hive_path")
+                .help("Path to the pre-generated hive file for the target binary")
+                .value_hint(ValueHint::FilePath)
+                .required(true)
+                .validator(|s| {
+                    let pb = PathBuf::from(s);
+                    if !pb.exists() {
+                        return Err(format!("Hive file @ {:?} does not exist!", pb))
+                    }
+                    pb.canonicalize().map_err(err_str)
+                })
+        )
+        .arg(
+            Arg::new("filter")
+                .required(true)
+                .help("Address range to filter")
+                .validator(parse_capture_filter)
+                .value_hint(ValueHint::Other)
+        )
+        .arg(
+            Arg::new("global_buffer_count")
+                .default_value("400")
+                .help("the number of ToPA entries to allocate per CPU")
+                .short('c')
+                .long("buffer_count")
+                .validator(|s| s.parse::<u32>())
+                .value_hint(ValueHint::Other)
+        )
+        .arg(
+            Arg::new("page_power")
+                .default_value("5")
+                .help("2**page_power ToPA pages will be allocated")
+                .short('p')
+                .long("page_power")
+                .validator(|s| s.parse::<u8>())
+                .value_hint(ValueHint::Other)
+        )
+        .arg(Arg::new("command")
+            .required(true)
+            .takes_value(true)
+            .multiple_values(true)
+            .value_hint(ValueHint::CommandWithArguments)
+            .last(true)
+        )
+        .get_matches();
+
+    let hive_path: PathBuf = matches.value_of_t("hive_path").unwrap();
+    let filter = parse_capture_filter(matches.value_of("filter").expect("filter must be provided"))?;
+    let cmdline = matches.values_of("command").unwrap().collect::<Vec<_>>();
+    let buffer_count: u32 = matches.value_of_t("global_buffer_count").unwrap();
+    let page_power: u8 = matches.value_of_t("page_power").unwrap();
+
+    println!("hive_path={hive_path:?}, filters={:?}, cmdline={cmdline:?}");
+
+    let clk_pre_all = get_epoch_ms();
+
+    let hive = HoneyBeeHive::load(
+        hive_path.as_os_str().to_str().expect("hive_path is not valid UTF-8, could not be decoded!")
+    )
+        .expect("Could not open Hive file!");
+
+    let clk_post_hive_load = get_epoch_ms();
+
+    // CAPTURE
+    let mut child = spawn_suspended(&cmdline).expect("Could not spawn child process");
+
+    let clk_post_child_spawn = get_epoch_ms();
+    pin_process_to_cpu(child.id(), 0u16);
+
+    let mut capture_session = CaptureSession::new(0).expect("Could not start capture session");
+    capture_session.set_global_buffer_size(buffer_count, page_power).expect("Could not set global buffer sizes");
+    println!("capture_session: {:?}", capture_session);
+    capture_session.configure_tracing(child.id(), &[filter]).expect("Could not configure tracing!");
+
+    capture_session.set_trace_enable(true, true).expect("Could not enable tracing!");
+
+    let clk_pre_unsuspend = get_epoch_ms();
+    unsuspend_process(child.id());
+
+    let exit_status = child.wait().expect("Failed to wait for child pid!");
+    let clk_post_child_exit = get_epoch_ms();
+    println!("Child returned with status code {:?}", exit_status);
+    capture_session.set_trace_enable(false, false).expect("Could not disable trace after child exited");
+
+    let trace = capture_session.get_trace().expect("Could not retrieve trace!");
+    println!("Got trace of length: {:?} {:?}", trace.len(), &trace[0..std::cmp::min(trace.len(), 100)]);
+    let clk_post_get_trace = get_epoch_ms();
+    // ANALYZE
+
+    let mut cov = FullTrace64Bit::new(hive.uvip_slide());
+    // let mut cov = BlockEdgeSetCoverageInfo::new(hive.uvip_slide());
+    let mut analysis_session = AnalysisSession::new(hive).expect("Could not create analysis session!");
+    analysis_session.reconfigure_with_terminated_trace_buffer(
+        trace,
+        filter.start.try_into().unwrap()
+    ).expect("Failed to reconfigure analysis session");
+
+    let clk_post_configure_with_terminated_buffer = get_epoch_ms();
+
+    analysis_session.decode_with_callback(|block| {
+        cov.record_block(block.try_into().unwrap())
+    }).expect("Could not decode trace");
+
+    let clk_post_decode = get_epoch_ms();
+    let (nvals, nbytes) = cov.report_sizes();
+    // let edges = cov.bbs.into_iter().unique().collect::<Vec<_>>();
+    let clk_post_unique = get_epoch_ms();
+
+    let timestamps = [clk_pre_all, clk_post_hive_load, clk_post_child_spawn, clk_pre_unsuspend, clk_post_child_exit, clk_post_get_trace, clk_post_configure_with_terminated_buffer, clk_post_decode, clk_post_unique];
+    // let timestamps = timestamps[1..].iter()
+    //     .map(|curr| curr - timestamps[0])
+    //     .collect::<Vec<_>>();
+    println!("timestamps: {:?}", timestamps);
+    let total_time = timestamps[timestamps.len() - 1] - timestamps[0];
+    let child_time = timestamps[4] - timestamps[3];
+    let decode_time = timestamps[7] - timestamps[6];
+    let timestamps = timestamps[..timestamps.len()-1].iter()
+        .zip(timestamps[1..].iter())
+        .map(|(prev, curr)| curr - prev)
+        .zip(&["load hive", "spawn child", "cpu pinned", "child_execution", "get_trace", "configure with buffer", "decode", "unique"])
+        .collect::<Vec<_>>();
+    println!("timestamps: {:?}", timestamps);
+
+    let percent_slower = ((total_time as f64) / child_time as f64) * 100f64;
+    let percent_slower_string = format!("{:.2}", percent_slower);
+
+    println!("total time taken: {:?}", timestamps.iter().map(|(x, _)| *x).collect::<Vec<u128>>().into_iter().sum::<u128>());
+    println!("percent slowdown: {}", percent_slower_string);
+    // println!("Trace length: {:?}", cov.bbs.len());
+    println!("Data size of coverage stats: 0x{:x}", datasize::data_size(&cov));
+    cov.print_result();
+
+    let name = cov.name();
+    let msg = format!("{name},{percent_slower_string},{child_time},{decode_time},{nvals},{nbytes}\n");
+    append_to_file(&format!("stats_{}.csv", cmdline[0].split("/").last().unwrap()), &msg);
+    // println!("Unique edges: {:?}", edges.len());
+    // println!(
+    //     "{}\n",
+    //     cov.bbs.len(),
+    // );
+    // let blockreprs = cov.bbs.iter().map(|x| format!("0x{:x}", x)).collect::<Vec<_>>();
+    // println!("{:?}", blockreprs);
+
+
+    Ok(())
+}

--- a/rust-honey_analyzer/src/capture_filter.rs
+++ b/rust-honey_analyzer/src/capture_filter.rs
@@ -1,0 +1,33 @@
+pub use rust_honey_analyzer_sys::ha_capture_session_range_filter as CaptureFilter;
+
+fn parse_filter_address(s: &str) -> Result<u64, String> {
+    parse_int::parse::<u64>(s)
+        .map_err(|e| e.to_string())
+}
+
+pub fn parse_capture_filter(s: &str) -> Result<CaptureFilter, String> {
+    let mut iter = s.split("-");
+    match (iter.next(), iter.next(), iter.next(), iter.next()) {
+
+        (Some(start), Some(end), None, None) => Ok(
+            CaptureFilter {
+                enabled: true as u8,
+                start: parse_filter_address(start)?,
+                stop: parse_filter_address(end)?
+            }),
+
+        (Some(enabled), Some(start), Some(end), None) => Ok(
+            CaptureFilter{
+                enabled: (enabled == "false") as u8,
+                start: parse_filter_address(start)?,
+                stop: parse_filter_address(end)?
+            }),
+
+        other => Err(
+            format!(
+                "Could not parse {:?} as a CaptureFilter: expected: {{start}}-{{end}}! Got {:?} after splitting",
+                s, other
+            )
+        )
+    }
+}

--- a/rust-honey_analyzer/src/capture_session.rs
+++ b/rust-honey_analyzer/src/capture_session.rs
@@ -1,0 +1,102 @@
+use std::{ptr};
+
+use nix::{unistd::Pid, errno::Errno, sched::CpuSet};
+use rust_honey_analyzer_sys::*;
+use crate::capture_filter::CaptureFilter;
+
+#[derive(Debug)]
+pub struct CaptureSession {
+    sess: ha_capture_session_t,
+    cpu_id: u16
+}
+
+type ErrnoResult<T> = std::result::Result<T, (String, Errno)>;
+
+impl Drop for CaptureSession {
+    fn drop(&mut self) {
+        unsafe {
+            ha_capture_session_free(self.sess)
+        }
+    }
+}
+fn errno_err<T>(reason: &str, errno: i32) -> ErrnoResult<T> {
+    Err((String::from(reason), Errno::from_i32(errno)))
+}
+impl CaptureSession {
+    pub fn new(cpu_id: u16) -> ErrnoResult<CaptureSession> {
+        let mut x : ha_capture_session_t = ptr::null_mut();
+        unsafe {
+            println!("Calling ha_capture_session_alloc");
+            let res  = ha_capture_session_alloc(&mut x, cpu_id);
+            if res < 0 {
+                return errno_err("ha_capture_session_alloc", -res);
+            }
+            return Ok(CaptureSession{
+                sess: x,
+                cpu_id
+            })
+        }
+    }
+    pub fn set_global_buffer_size(&mut self, buffer_count: u32, page_power: u8) -> ErrnoResult<()> {
+        unsafe {
+            let res = ha_capture_session_set_global_buffer_size(self.sess, buffer_count, page_power);
+            if res < 0 {
+                return errno_err("ha_capture_session_set_global_buffer_size", -res);
+            }
+            Ok(())
+        }
+    }
+    pub fn set_trace_enable(&mut self, enabled: bool, reset_output: bool) -> ErrnoResult<()> {
+        unsafe {
+            let res = ha_capture_session_set_trace_enable(self.sess, enabled as u8, reset_output as u8);
+            if res < 0 {
+                return errno_err("ha_capture_session_set_trace_enable", -res);
+            }
+            Ok(())
+        }
+    }
+    pub fn configure_tracing(&mut self, pid: u32, filters: &[CaptureFilter]) -> ErrnoResult<()> {
+        if filters.len() > 4{
+            return Err((String::from("too many filters"), Errno::EINVAL))
+        }
+        // Ensure `pid` is bound (`sched_set_affinity`) to this session's CPU for accurate results!
+        let cpu_set = nix::sched::sched_getaffinity(Pid::from_raw(pid.try_into().unwrap())).expect("Cannot set process affinity");
+        let valid_cpus = (0..CpuSet::count())
+            .filter_map(|i| -> Option<Result<u16, (String, Errno)>> {
+                    match cpu_set.is_set(i) {
+                        Ok(true) => Some(Ok(i.try_into().unwrap())),
+                        Ok(false) => None,
+                        Err(e) => Some(Err((String::from("cpu_set.is_set"), e)))
+                    }
+                }
+            )
+            .collect::<Result<Vec<_>, _>>()?;
+
+        assert!(valid_cpus.len() == 1,
+            "Pid {} is not bound to a single CPU, getting an accurate trace for it will be impossible! It can run on CPUs {:?}",
+            pid, valid_cpus
+        );
+        assert!(valid_cpus[0] == self.cpu_id, "Pid {} is not bound to this session's CPU #{}.", pid, self.cpu_id);
+
+        unsafe {
+            let res = ha_capture_session_configure_tracing(self.sess, pid, filters.as_ptr());
+            if res < 0 {
+                return errno_err("ha_capture_session_configure_tracing", -res);
+            }
+            Ok(())
+        }
+    }
+    pub fn get_trace(&self) -> ErrnoResult<Vec<u8>> {
+        let mut trace_buffer: *mut u8 = std::ptr::null_mut();
+        let mut trace_length: u64 = 0;
+        unsafe {
+            let res = ha_capture_session_get_trace(self.sess, &mut trace_buffer, &mut trace_length);
+            if res < 0 {
+                return errno_err("ha_capture_session_get_trace", -res);
+            }
+            assert!(!trace_buffer.is_null());
+            let slice = std::slice::from_raw_parts_mut(trace_buffer, trace_length as usize + 1);
+            Ok(slice.to_vec())
+        }
+    }
+}

--- a/rust-honey_analyzer/src/example_coverage_info/block_btreeset.rs
+++ b/rust-honey_analyzer/src/example_coverage_info/block_btreeset.rs
@@ -1,0 +1,36 @@
+use std::collections::{BTreeSet};
+
+use datasize::{DataSize, data_size};
+
+use super::CoverageTracker;
+
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, DataSize)]
+pub struct BlockBTreeSetCoverageInfo {
+    hive_slide: usize,
+    pub block_set: BTreeSet<usize>,
+}
+
+impl BlockBTreeSetCoverageInfo {
+    pub fn new(hive_slide: usize) -> Self {
+        Self {
+            hive_slide,
+            block_set: BTreeSet::new(),
+        }
+    }
+}
+impl CoverageTracker for BlockBTreeSetCoverageInfo {
+    fn name(&self) -> &'static str {
+        "BlockBTreeSetCoverageInfo"
+    }
+    fn record_block(&mut self, block: usize) {
+        self.block_set.insert(block);
+    }
+    fn print_result(&self) {
+        println!("Blocks: {} values = {} bytes", self.block_set.len(), data_size(&self.block_set));
+    }
+    fn report_sizes(&self) -> (usize, usize) {
+        (self.block_set.len(), data_size(&self.block_set))
+    }
+}
+

--- a/rust-honey_analyzer/src/example_coverage_info/block_hashset.rs
+++ b/rust-honey_analyzer/src/example_coverage_info/block_hashset.rs
@@ -1,0 +1,36 @@
+use std::collections::HashSet;
+
+use datasize::{DataSize, data_size};
+
+use super::CoverageTracker;
+
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, DataSize)]
+pub struct BlockHashSetCoverageInfo {
+    hive_slide: usize,
+    pub block_set: HashSet<usize>,
+}
+
+impl BlockHashSetCoverageInfo {
+    pub fn new(hive_slide: usize) -> Self {
+        Self {
+            hive_slide,
+            block_set: HashSet::with_capacity(100),
+        }
+    }
+}
+impl CoverageTracker for BlockHashSetCoverageInfo {
+    fn name(&self) -> &'static str {
+        "BlockHashSetCoverageInfo"
+    }
+    fn record_block(&mut self, block: usize) {
+        self.block_set.insert(block);
+    }
+    fn print_result(&self) {
+        println!("Basic blocks: {} values = {} bytes", self.block_set.len(), data_size(&self.block_set));
+    }
+    fn report_sizes(&self) -> (usize, usize) {
+        (self.block_set.len(), data_size(&self.block_set))
+    }
+}
+

--- a/rust-honey_analyzer/src/example_coverage_info/edge_btreeset.rs
+++ b/rust-honey_analyzer/src/example_coverage_info/edge_btreeset.rs
@@ -1,0 +1,41 @@
+use std::collections::BTreeSet;
+
+use datasize::{DataSize, data_size};
+
+use super::CoverageTracker;
+
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, DataSize)]
+pub struct EdgeBTreeSetCoverageInfo {
+    hive_slide: usize,
+    last_block: usize,
+    pub edge_set: BTreeSet<(usize, usize)>,
+}
+
+impl EdgeBTreeSetCoverageInfo {
+    pub fn new(hive_slide: usize) -> Self {
+        Self {
+            hive_slide,
+            last_block: 0,
+            edge_set: BTreeSet::new(),
+        }
+    }
+}
+impl CoverageTracker for EdgeBTreeSetCoverageInfo {
+    fn name(&self) -> &'static str {
+        "EdgeBTreeSetCoverageInfo"
+    }
+    fn record_block(&mut self, block: usize) {
+        let last = self.last_block;
+        self.last_block = block;
+
+        self.edge_set.insert((last, block));
+    }
+    fn print_result(&self) {
+        println!("Edges:        {} values = {} bytes", self.edge_set.len(),  data_size(&self.edge_set));
+    }
+    fn report_sizes(&self) -> (usize, usize) {
+        (self.edge_set.len(), data_size(&self.edge_set))
+    }
+}
+

--- a/rust-honey_analyzer/src/example_coverage_info/edge_hashset.rs
+++ b/rust-honey_analyzer/src/example_coverage_info/edge_hashset.rs
@@ -1,0 +1,41 @@
+use std::collections::HashSet;
+
+use datasize::{DataSize, data_size};
+
+use super::CoverageTracker;
+
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, DataSize)]
+pub struct EdgeHashSetCoverageInfo {
+    hive_slide: usize,
+    last_block: usize,
+    pub edge_set: HashSet<(usize, usize)>,
+}
+
+impl EdgeHashSetCoverageInfo {
+    pub fn new(hive_slide: usize) -> Self {
+        Self {
+            hive_slide,
+            last_block: 0,
+            edge_set: HashSet::with_capacity(1000),
+        }
+    }
+}
+impl CoverageTracker for EdgeHashSetCoverageInfo {
+    fn name(&self) -> &'static str {
+        "EdgeHashSetCoverageInfo"
+    }
+    fn record_block(&mut self, block: usize) {
+        let last = self.last_block;
+        self.last_block = block;
+
+        self.edge_set.insert((last, block));
+    }
+    fn print_result(&self) {
+        println!("Edges:        {} values = {} bytes", self.edge_set.len(),  data_size(&self.edge_set));
+    }
+    fn report_sizes(&self) -> (usize, usize) {
+        (self.edge_set.len(), data_size(&self.edge_set))
+    }
+}
+

--- a/rust-honey_analyzer/src/example_coverage_info/fulltrace_32bit.rs
+++ b/rust-honey_analyzer/src/example_coverage_info/fulltrace_32bit.rs
@@ -1,0 +1,36 @@
+use datasize::{DataSize, data_size};
+
+use super::CoverageTracker;
+
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, DataSize)]
+pub struct FullTrace32Bit {
+    hive_slide: usize,
+    pub bbs: Vec<u32>,
+}
+
+impl FullTrace32Bit {
+    pub fn new(hive_slide: usize, ) -> Self {
+        let vec = Vec::with_capacity(1000);
+        Self {
+            hive_slide,
+            bbs: vec,
+        }
+    }
+}
+impl CoverageTracker for FullTrace32Bit {
+    fn name(&self) -> &'static str {
+        "FullTrace32Bit"
+    }
+    fn record_block(&mut self, block: usize) {
+        self.bbs.push((block - self.hive_slide).try_into().unwrap());
+    }
+    fn print_result(&self) {
+        let l = self.bbs.len();
+        println!("Trace length: {} values = {} bytes", l, 4 * l);
+    }
+    fn report_sizes(&self) -> (usize, usize) {
+        (self.bbs.len(), data_size(&self.bbs))
+    }
+}
+

--- a/rust-honey_analyzer/src/example_coverage_info/fulltrace_64bit.rs
+++ b/rust-honey_analyzer/src/example_coverage_info/fulltrace_64bit.rs
@@ -1,0 +1,39 @@
+use datasize::{DataSize, data_size};
+use itertools::Itertools;
+
+use super::CoverageTracker;
+
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, DataSize)]
+pub struct FullTrace64Bit {
+    hive_slide: usize,
+    pub bbs: Vec<usize>,
+}
+
+impl FullTrace64Bit {
+    pub fn new(hive_slide: usize) -> FullTrace64Bit {
+        let vec = Vec::with_capacity(1000);
+        FullTrace64Bit {
+            hive_slide,
+            bbs: vec,
+        }
+    }
+}
+impl CoverageTracker for FullTrace64Bit {
+    fn name(&self) -> &'static str {
+        "FullTrace64Bit"
+    }
+    fn record_block(&mut self, block: usize) {
+        self.bbs.push(block);
+    }
+    fn print_result(&self) {
+        let l = self.bbs.len();
+        println!("Trace length: {} values = {} bytes", l, 8 * l);
+    }
+    fn report_sizes(&self) -> (usize, usize) {
+        let uniq_edges = self.bbs[0..(self.bbs.len()-1)].iter().zip(self.bbs[1..].iter()).unique().collect::<Vec<_>>();
+        // (self.bbs.len(), data_size(&self.bbs))
+        (uniq_edges.len(), data_size(&self.bbs))
+    }
+}
+

--- a/rust-honey_analyzer/src/example_coverage_info/less_trivial_dedup_fulltrace_32bit.rs
+++ b/rust-honey_analyzer/src/example_coverage_info/less_trivial_dedup_fulltrace_32bit.rs
@@ -1,0 +1,47 @@
+use std::mem::size_of;
+
+use datasize::{DataSize, data_size};
+
+use super::CoverageTracker;
+
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, DataSize)]
+pub struct LessTrivialDedupFullTrace32Bit {
+    hive_slide: usize,
+    prevprev: usize,
+    prev: usize,
+    pub bbs: Vec<u32>,
+}
+
+impl LessTrivialDedupFullTrace32Bit {
+    pub fn new(hive_slide: usize, ) -> Self {
+        let vec = Vec::with_capacity(1000);
+        Self {
+            hive_slide,
+            prevprev : 0,
+            prev : 0,
+            bbs: vec,
+        }
+    }
+}
+impl CoverageTracker for LessTrivialDedupFullTrace32Bit {
+    fn name(&self) -> &'static str {
+        "LessTrivialDedupFullTrace32Bit"
+    }
+    fn record_block(&mut self, block: usize) {
+        let (prev, prevprev) = (self.prev, self.prevprev);
+        (self.prev, self.prevprev) = (block, prev);
+        if block == prev && block == prevprev {
+            return;
+        }
+        self.bbs.push((block - self.hive_slide).try_into().unwrap());
+    }
+    fn print_result(&self) {
+        let l = self.bbs.len();
+        println!("Trace length: {} values = {} bytes", l, 4 * l);
+    }
+    fn report_sizes(&self) -> (usize, usize) {
+        (self.bbs.len(), data_size(&self.bbs))
+    }
+}
+

--- a/rust-honey_analyzer/src/example_coverage_info/mod.rs
+++ b/rust-honey_analyzer/src/example_coverage_info/mod.rs
@@ -1,0 +1,35 @@
+pub trait CoverageTracker {
+    fn name(&self) -> &'static str;
+    fn record_block(&mut self, block: usize);
+
+    fn print_result(&self);
+
+    fn report_sizes(&self) -> (usize, usize);
+}
+
+mod fulltrace_32bit;
+mod fulltrace_64bit;
+
+mod xordiff_compressed_trace_uleb128;
+mod less_trivial_dedup_fulltrace_32bit;
+
+mod trivial_dedup_fulltrace_32bit;
+mod trivial_dedup_fulltrace_64bit;
+
+mod edge_hashset;
+mod edge_btreeset;
+mod block_btreeset;
+mod block_hashset;
+
+
+pub use fulltrace_32bit::FullTrace32Bit;
+pub use fulltrace_64bit::FullTrace64Bit;
+pub use trivial_dedup_fulltrace_32bit::TrivialDedupFullTrace32Bit;
+pub use trivial_dedup_fulltrace_64bit::TrivialDedupFullTrace64Bit;
+pub use less_trivial_dedup_fulltrace_32bit::LessTrivialDedupFullTrace32Bit;
+
+pub use edge_hashset::EdgeHashSetCoverageInfo;
+pub use edge_btreeset::EdgeBTreeSetCoverageInfo;
+pub use block_hashset::BlockHashSetCoverageInfo;
+pub use block_btreeset::BlockBTreeSetCoverageInfo;
+pub use xordiff_compressed_trace_uleb128::XorDiffULeb128CompressedTrace;

--- a/rust-honey_analyzer/src/example_coverage_info/trivial_dedup_fulltrace_32bit.rs
+++ b/rust-honey_analyzer/src/example_coverage_info/trivial_dedup_fulltrace_32bit.rs
@@ -1,0 +1,43 @@
+use datasize::{DataSize, data_size};
+
+use super::CoverageTracker;
+
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, DataSize)]
+pub struct TrivialDedupFullTrace32Bit {
+    hive_slide: usize,
+    last_block: usize,
+    pub bbs: Vec<u32>,
+}
+
+impl TrivialDedupFullTrace32Bit {
+    pub fn new(hive_slide: usize, ) -> Self {
+        let vec = Vec::with_capacity(1000);
+        Self {
+            hive_slide,
+            last_block : 0,
+            bbs: vec,
+        }
+    }
+}
+impl CoverageTracker for TrivialDedupFullTrace32Bit {
+    fn name(&self) -> &'static str {
+        "TrivialDedupFullTrace32Bit"
+    }
+    fn record_block(&mut self, block: usize) {
+        let last = self.last_block;
+        self.last_block = block;
+        if last == block {
+            return;
+        }
+        self.bbs.push((block - self.hive_slide).try_into().unwrap());
+    }
+    fn print_result(&self) {
+        let l = self.bbs.len();
+        println!("Trace length: {} values = {} bytes", l, 4 * l);
+    }
+    fn report_sizes(&self) -> (usize, usize) {
+        (self.bbs.len(), data_size(&self.bbs))
+    }
+}
+

--- a/rust-honey_analyzer/src/example_coverage_info/trivial_dedup_fulltrace_64bit.rs
+++ b/rust-honey_analyzer/src/example_coverage_info/trivial_dedup_fulltrace_64bit.rs
@@ -1,0 +1,43 @@
+use datasize::{DataSize, data_size};
+
+use super::CoverageTracker;
+
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, DataSize)]
+pub struct TrivialDedupFullTrace64Bit {
+    hive_slide: usize,
+    last_block: usize,
+    pub bbs: Vec<usize>,
+}
+
+impl TrivialDedupFullTrace64Bit {
+    pub fn new(hive_slide: usize) -> Self {
+        let vec = Vec::with_capacity(1000);
+        Self {
+            hive_slide,
+            last_block: 0,
+            bbs: vec,
+        }
+    }
+}
+impl CoverageTracker for TrivialDedupFullTrace64Bit {
+    fn name(&self) -> &'static str {
+        "TrivialDedupFullTrace64Bit"
+    }
+    fn record_block(&mut self, block: usize) {
+        let last = self.last_block;
+        self.last_block = block;
+        if last == block {
+            return;
+        }
+        self.bbs.push(block);
+    }
+    fn print_result(&self) {
+        let l = self.bbs.len();
+        println!("Trace length: {} values = {} bytes", l, 8 * l);
+    }
+    fn report_sizes(&self) -> (usize, usize) {
+        (self.bbs.len(), data_size(&self.bbs))
+    }
+}
+

--- a/rust-honey_analyzer/src/example_coverage_info/xordiff_compressed_trace_uleb128.rs
+++ b/rust-honey_analyzer/src/example_coverage_info/xordiff_compressed_trace_uleb128.rs
@@ -1,0 +1,54 @@
+use datasize::{DataSize, data_size};
+use uleb128::WriteULeb128Ext;
+
+use super::CoverageTracker;
+
+
+#[derive(Debug, Eq, PartialEq, Clone, Default, DataSize)]
+pub struct XorDiffULeb128CompressedTrace {
+    hive_slide: usize,
+    last_block: usize,
+    num_vals: usize,
+    compressed_trace: Vec<u8>,
+}
+
+impl XorDiffULeb128CompressedTrace {
+    pub fn new(hive_slide: usize) -> XorDiffULeb128CompressedTrace {
+        let vec = Vec::with_capacity(1000);
+        XorDiffULeb128CompressedTrace {
+            hive_slide,
+            last_block: 0,
+            num_vals: 0,
+            compressed_trace: vec,
+        }
+    }
+}
+impl CoverageTracker for XorDiffULeb128CompressedTrace {
+    fn name(&self) -> &'static str {
+        "CompressedTraceXorDiffULeb128"
+    }
+    fn record_block(&mut self, block: usize) {
+        let last = self.last_block;
+        self.last_block = block;
+
+        if last == block {
+            return;
+        }
+
+        let xordiff = block ^ last;
+        self.num_vals += 1;
+        // println!("0x{:x} ^ 0x{:x} = 0x{:x}", block, last, block ^ last);
+
+        let mut wtr = vec![];
+        wtr.write_uleb128_u32(xordiff.try_into().unwrap()).unwrap();
+        self.compressed_trace.append(&mut wtr);
+        self.last_block = block;
+    }
+    fn print_result(&self) {
+        println!("Compressed length: {} values = {} bytes", self.num_vals, self.compressed_trace.len());
+    }
+    fn report_sizes(&self) -> (usize, usize) {
+        (self.num_vals, data_size(&self.compressed_trace))
+    }
+}
+

--- a/rust-honey_analyzer/src/hive.rs
+++ b/rust-honey_analyzer/src/hive.rs
@@ -1,0 +1,48 @@
+use std::ffi::CString;
+
+use nix::errno::Errno;
+use rust_honey_analyzer_sys::*;
+
+pub struct HoneyBeeHive {
+    hive: *mut hb_hive,
+}
+
+type ErrnoResult<T> = std::result::Result<T, Errno>;
+
+impl Drop for HoneyBeeHive {
+    fn drop(&mut self) {
+        unsafe {
+            hb_hive_free(self.hive)
+        }
+    }
+}
+impl HoneyBeeHive {
+    pub fn load(path: &str) -> ErrnoResult<HoneyBeeHive> {
+        let cstr = CString::new(path).unwrap();
+        unsafe {
+            let res  = hb_hive_alloc(cstr.as_ptr());
+            assert!(!res.is_null(), "loading hive failed, error should have been printed to the console!");
+            Ok(HoneyBeeHive{
+                hive: res,
+            })
+        }
+    }
+    pub fn get_inner(&mut self) -> &mut hb_hive {
+        unsafe { &mut *self.hive }
+    }
+    pub fn describe_block(&self, idx: usize) {
+        unsafe {
+            hb_hive_describe_block(self.hive, idx.try_into().unwrap());
+        }
+    }
+    pub fn uvip_slide(&self) -> usize {
+        unsafe {
+            (*self.hive).uvip_slide.try_into().unwrap()
+        }
+    }
+    pub fn block_count(&self) -> usize {
+        unsafe {
+            (*self.hive).block_count.try_into().unwrap()
+        }
+    }
+}

--- a/rust-honey_analyzer/src/lib.rs
+++ b/rust-honey_analyzer/src/lib.rs
@@ -1,0 +1,7 @@
+
+pub mod capture_session;
+pub mod hive;
+pub mod analysis_session;
+pub mod pt_decoder_status;
+pub mod example_coverage_info;
+pub mod capture_filter;

--- a/rust-honey_analyzer/src/pt_decoder_status.rs
+++ b/rust-honey_analyzer/src/pt_decoder_status.rs
@@ -1,0 +1,55 @@
+use rust_honey_analyzer_sys::*;
+
+// /** No error */
+// HA_PT_DECODER_NO_ERROR = 0,
+// /** The trace ended. This is not an error but rather an indication to stop */
+// HA_PT_DECODER_END_OF_STREAM = 1,
+// /** There was an internal decoder error. Probably not your fault. */
+// HA_PT_DECODER_INTERNAL = 2,
+// /** A sync operation failed because the target PSB could not be found. */
+// HA_PT_DECODER_COULD_NOT_SYNC = 3,
+// /**
+//  * An operation was requested which could not be completed given the trace.
+//  * This can mean one of three things:
+//  * 1. The decoder is buggy
+//  * 2. The analysis is buggy
+//  * 3. The mapping between the binary and the decoder is incorrect (leading to bad analysis)
+//  */
+// HA_PT_DECODER_TRACE_DESYNC = 4,
+// /** An unsupported packet was found in the PT stream. */
+// HA_PT_DECODER_UNSUPPORTED_TRACE_PACKET = 5,
+// /** The target address was not found in the binary map. */
+// HA_PT_DECODER_NO_MAP = 6,
+
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PTDecoderStatus {
+    NoError = ha_pt_decoder_status_HA_PT_DECODER_NO_ERROR as u32,
+    EndOfStream = ha_pt_decoder_status_HA_PT_DECODER_END_OF_STREAM as u32,
+    Internal = ha_pt_decoder_status_HA_PT_DECODER_INTERNAL as u32,
+    CouldNotSync = ha_pt_decoder_status_HA_PT_DECODER_COULD_NOT_SYNC as u32,
+    TraceDesync = ha_pt_decoder_status_HA_PT_DECODER_TRACE_DESYNC as u32,
+    UnsupportedTracePacket = ha_pt_decoder_status_HA_PT_DECODER_UNSUPPORTED_TRACE_PACKET as u32,
+    NoMap = ha_pt_decoder_status_HA_PT_DECODER_NO_MAP as u32,
+}
+
+impl TryFrom<i32> for PTDecoderStatus {
+    type Error = String;
+
+    fn try_from(value: i32) -> Result<PTDecoderStatus, String> {
+        let res = match value as u32 {
+            0 => Ok(PTDecoderStatus::NoError),
+            1 => Ok(PTDecoderStatus::EndOfStream),
+            2 => Ok(PTDecoderStatus::Internal),
+            3 => Ok(PTDecoderStatus::CouldNotSync),
+            4 => Ok(PTDecoderStatus::TraceDesync),
+            5 => Ok(PTDecoderStatus::UnsupportedTracePacket),
+            6 => Ok(PTDecoderStatus::NoMap),
+            _ => Err(format!("Unknown PTDecoderStatus: {:?}", value))
+        };
+        if let Ok(val) = res {
+            assert_eq!(val as i32, value);
+        }
+        res
+    }
+}


### PR DESCRIPTION
I implemented low and high-level Rust bindings to allow writing an Intel PT tracer in Rust using HoneyBee for decoding. The first milestone of reimplementing `honey_coverage` in Rust is done (in `rust-honey_analyzer/src/bin/honey_analyzer.rs`).

I'm not sure if you want me to merge the Rust bindings here, or would prefer separate repositories, that's why I split out my rust-specific commits. 

The build process is currently still ad-hoc (assumes the cmake was run in `Honeybee/build`), that will be improved in the future.

Some initial examples with profiling using `cargo flamegraph` show that the Rust bindings have very little overhead depending on which coverage_tracker you use. For any non-trivial program, with the `TrivialDedupFullTrace32Bit` coverage collector I usually get around 25-75% overhead over the native execution of the target program, going as low as 2% on super-long running processes.